### PR TITLE
Remove i686 from config

### DIFF
--- a/config
+++ b/config
@@ -22,7 +22,7 @@ LOCK_TIMEOUT=300
 
 STAGING="$HOME/staging"
 TMPDIR="/var/tmp"
-ARCHES=(i686 x86_64)
+ARCHES=(x86_64)
 DBEXT=".db.tar.gz"
 FILESEXT=".files.tar.gz"
 PKGEXT=".pkg.tar.?z"

--- a/cron-jobs/check_archlinux/check_packages.py
+++ b/cron-jobs/check_archlinux/check_packages.py
@@ -366,15 +366,15 @@ def print_usage():
 	print "Options:"
 	print "  --abs-tree=<path[,path]>      Check the specified tree(s) (default : /var/abs)"
 	print "  --repos=<r1,r2,...>           Check the specified repos (default : core,extra)"
-	print "  --arch=<i686|x86_64>          Check the specified arch (default : i686)"
+	print "  --arch=<i686|x86_64>          Check the specified arch (default : x86_64)"
 	print "  --repo-dir=<path>             Check the dbs at the specified path (default : /srv/ftp)"
 	print "  -h, --help                    Show this help and exit"
 	print ""
 	print "Examples:"
 	print "\n  Check core and extra in existing abs tree:"
-	print "    ./check_packages.py --abs-tree=/var/abs --repos=core,extra --arch=i686"
+	print "    ./check_packages.py --abs-tree=/var/abs --repos=core,extra --arch=x86_64"
 	print "\n  Check community:"
-	print "    ./check_packages.py --abs-tree=/var/abs --repos=community --arch=i686"
+	print "    ./check_packages.py --abs-tree=/var/abs --repos=community --arch=x86_64"
 	print ""
 
 if __name__ == "__main__":
@@ -383,7 +383,7 @@ if __name__ == "__main__":
 	## Default list of repos to check
 	repos = ['core', 'extra']
 	## Default arch
-	arch = "i686"
+	arch = "x86_64"
 	## Default repodir
 	repodir = "/srv/ftp"
 

--- a/cron-jobs/check_archlinux/parse_pkgbuilds.sh
+++ b/cron-jobs/check_archlinux/parse_pkgbuilds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Usage : parse_pkgbuilds.sh arch <pkgbuilds_dir1,dir2,...>
-# Example : parse_pkgbuilds.sh i686 /var/abs/core /var/abs/extra
+# Example : parse_pkgbuilds.sh x86_64 /var/abs/core /var/abs/extra
 
 exit() { return; }
 

--- a/test/lib/common.bash
+++ b/test/lib/common.bash
@@ -98,6 +98,7 @@ setup() {
 	SOURCE_CLEANUP_DESTDIR="${TMP}/source-cleanup"
 	STAGING="${TMP}/staging"
 	TMPDIR="${TMP}/tmp"
+	ARCHES=(x86_64 i686)
 	CLEANUP_DRYRUN=false
 	SOURCE_CLEANUP_DRYRUN=false
 eot


### PR DESCRIPTION
We dropped it long ago and this should be reflected here rather than
being changed on our servers only.

Signed-off-by: Florian Pritz <bluewind@xinu.at>