### PR TITLE
test: verify that PKGEXTS is treated as a glob

### DIFF
--- a/test/cases/db-update.bats
+++ b/test/cases/db-update.bats
@@ -92,7 +92,7 @@ load ../lib/common
 	db-update
 	checkPackage extra pkg-any-a
 
-	releasePackage extra pkg-any-a
+	PKGEXT=.pkg.tar.gz releasePackage extra pkg-any-a
 	run db-update
 	[ "$status" -ne 0 ]
 }

--- a/test/lib/common.bash
+++ b/test/lib/common.bash
@@ -23,8 +23,7 @@ __buildPackage() {
 
 	if [[ -n ${BUILDDIR} ]]; then
 		cache=${BUILDDIR}/$(__getCheckSum PKGBUILD)
-		if [[ -d ${cache} ]]; then
-			cp -Lv ${cache}/*${PKGEXT}{,.sig} ${pkgdest}
+		if cp -Lv ${cache}/*${PKGEXT}{,.sig} ${pkgdest} 2>/dev/null; then
 			return 0
 		else
 			mkdir -p ${cache}


### PR DESCRIPTION
test: db-update: @test "update same any package to same repository falls": change PKGEXT

This has the test change PKGEXT the second time it tries to release the
package.  Currently, this causes the tests to fail.  That's a good thing;
it's checking for the regression where db-functions:check_pkgrepos isn't
treating PKGEXT as a glob.

Without this, that regression didn't cause test failure because the checks
right after it were tripping anyway.

https://lists.archlinux.org/pipermail/arch-projects/2018-February/004742.html