### PR TITLE
Unbreak the testsuite by supporting pacman 5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE:=dbscripts/test
-RUN_OPTIONS:=--rm --network=none -v $(PWD):/dbscripts:ro --tmpfs=/tmp:exec --tmpfs=/build -w /dbscripts/test
+RUN_OPTIONS:=--rm --network=none -v $(PWD):/dbscripts:ro --tmpfs=/tmp:exec -w /dbscripts/test
 
 test-image:
 	docker build --pull -t $(IMAGE) test

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,8 +2,7 @@ FROM archlinux/base
 RUN pacman -Syu --noconfirm --needed sudo fakeroot awk subversion make kcov bash-bats gettext grep
 RUN pacman-key --init
 RUN echo '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel
-RUN useradd -N -g users -G wheel -m tester
-RUN install -d -m 1777 /build
+RUN useradd -N -g users -G wheel -d /build -m tester
 USER tester
 RUN echo -e "\
 Key-Type: RSA\n\


### PR DESCRIPTION
@pierres Is there a particular reason this was initially done via tmpfs?

Note that the specific error condition there will no longer be  triggered by pacman 5.1.1 whenever that lands, but I still consider it sort of bad practice (plus I want to more closely mimic makechrootpkg itself). AFAICT docker creates a new container each time regardless.

If it's especially useful to ensure the /build directory is not persisted between runs (efficiency? I don't know enough about how docker works) I think it makes more sense to use `makepkg --clean` in the testsuite itself.