### PR TITLE
test: Fix typoed variables

### DIFF
--- a/test/cases/ftpdir-cleanup.bats
+++ b/test/cases/ftpdir-cleanup.bats
@@ -111,7 +111,7 @@ __checkRepoRemovedPackage() {
 	ftpdir-cleanup
 
 	for arch in ${arches[@]}; do
-		__checkRepoRemovedPackage extra ${pkg[0]} ${arch}
+		__checkRepoRemovedPackage extra ${pkgs[0]} ${arch}
 	done
 
 	checkRemovedPackage extra ${pkgs[0]}

--- a/test/lib/common.bash
+++ b/test/lib/common.bash
@@ -272,7 +272,7 @@ checkRemovedPackageDB() {
 	if [[ ${pkgarches[@]} == any ]]; then
 		tarches=(${ARCHES[@]})
 	else
-		tarches=($pkgarches[@])
+		tarches=(${pkgarches[@]})
 	fi
 
 	for db in ${DBEXT} ${FILESEXT}; do


### PR DESCRIPTION
 - ftpdir-cleanup: ${pkg[0]} -> ${pkgs[0]}

   This mistake was introduced in 7628525156110022fa70ad91e4bc13ee8a3cceb0

 - test: common.bash: $pkgarches[@] -> ${pkgarches[@]}

   This mistake was introduced in 7628525156110022fa70ad91e4bc13ee8a3cceb0

This is identical to v2 of this patch posted on the mailing list https://lists.archlinux.org/pipermail/arch-projects/2018-June/004915.html