### PR TITLE
Add reproducible archive of packages.

### DIFF
--- a/config
+++ b/config
@@ -1,6 +1,8 @@
 #!/hint/bash
 
 FTP_BASE="/srv/ftp"
+ARCHIVE_BASE="/srv/archive"
+ARCHIVEUSER='archive'
 PKGREPOS=()
 PKGPOOL=''
 SRCPOOL=''

--- a/db-archive
+++ b/db-archive
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/config"
+
+if (( $# != 1 )); then
+	echo "usage: %s <pkgfile>" "${0##*/}"
+	exit 1
+fi
+
+if [[ -n ${ARCHIVEUSER} ]]; then
+	exec sudo -u "${ARCHIVEUSER}" bash "${BASH_SOURCE[0]}" "${@}"
+fi
+
+pkgfile=${1##*/}
+pkgname=${pkgfile%-*-*-*}
+archive_dir="${ARCHIVE_BASE}/packages/${pkgname:0:1}/${pkgname}"
+
+if [[ ! -f ${archive_dir}/${pkgfile} ]]; then
+	mkdir -p "${archive_dir}"
+	cp -np "${1}"{,.sig} "${archive_dir}/"
+fi

--- a/db-functions
+++ b/db-functions
@@ -165,20 +165,23 @@ repo_unlock () { #repo_unlock <repo-name> <arch>
 	fi
 }
 
+# usage: _grep_all_info pkgfile infofile key
+_grep_all_info() {
+	local _ret=()
+
+	mapfile -t _ret < <(/usr/bin/bsdtar -xOqf "$1" "${2}" | grep "^${3} = ")
+
+	printf '%s\n' "${_ret[@]#${3} = }"
+}
+
 # usage: _grep_pkginfo pkgfile pattern
 _grep_pkginfo() {
-	local _ret
-
-	_ret="$(/usr/bin/bsdtar -xOqf "$1" .PKGINFO | grep "^${2} = " | tail -1)"
-	echo "${_ret#${2} = }"
+	_grep_all_info "${1}" .PKGINFO "${2}" | tail -1
 }
 
 # usage: _grep_buildinfo pkgfile pattern
 _grep_buildinfo() {
-	local _ret
-
-	_ret="$(/usr/bin/bsdtar -xOqf "$1" .BUILDINFO | grep "^${2} = " | tail -1)"
-	echo "${_ret#${2} = }"
+	_grep_all_info "${1}" .BUILDINFO "${2}" | tail -1
 }
 
 # Get the package base or name as fallback
@@ -442,6 +445,26 @@ arch_repo_modify() {
 	popd >/dev/null
 
 	REPO_MODIFIED=1
+}
+
+# Verify the existence of dependent packages needed by a given pkgfile
+# usage: check_reproducible pkgfile
+check_reproducible() {
+	local pkg dir pkgs=() pkgfile pkgfiles=()
+
+	mapfile -t pkgs < <(_grep_all_info "${1}" .BUILDINFO installed)
+
+	for pkg in "${pkgs[@]}"; do
+		local pkgname=${pkg%-*-*-*}
+		for dir in "${ARCHIVE_BASE}/packages/${pkgname:0:1}/${pkgname}" "${STAGING}"/**/; do
+			if pkgfile="$(getpkgfile "${dir}/${pkg}"${PKGEXTS} 2>/dev/null)"; then
+				pkgfiles+=("${pkgfile}")
+				continue 2
+			fi
+		done
+		error "could not find existing or staged package for dependency %s" "${pkg}"
+		return 1
+	done
 }
 
 . "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/db-functions-${VCS}"

--- a/db-update
+++ b/db-update
@@ -61,6 +61,10 @@ for repo in "${repos[@]}"; do
 			if ! check_builddir "${pkg}"; then
 				die "Package %s was not built in a chroot" "$repo/${pkg##*/}"
 			fi
+			if ! check_reproducible "${pkg}"; then
+				error "Package %s is not reproducible." "${pkg}"
+				die "Ensure that all dependencies are available in the repositories or are added in the same db-update."
+			fi
 		done
 		if ! check_splitpkgs "${repo}" "${pkgs[@]}"; then
 			die "Missing split packages for %s" "$repo"
@@ -82,6 +86,7 @@ for repo in "${repos[@]}"; do
 			# any packages might have been moved by the previous run
 			if [[ -f ${pkg} ]]; then
 				mv "${pkg}" "$FTP_BASE/${PKGPOOL}"
+				"$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/db-archive" "${FTP_BASE}/${PKGPOOL}/${pkg##*/}"
 			fi
 			ln -s "../../../${PKGPOOL}/${pkgfile}" "$FTP_BASE/$repo/os/${pkgarch}"
 			# also move signatures

--- a/test/cases/db-update.bats
+++ b/test/cases/db-update.bats
@@ -87,6 +87,12 @@ load ../lib/common
 	checkPackage testing pkg-any-a 1-2
 }
 
+@test "archive package when releasing" {
+	releasePackage extra pkg-any-a
+	db-update
+	[[ -f ${ARCHIVE_BASE}/packages/p/pkg-any-a/pkg-any-a-1-1-any${PKGEXT} ]]
+}
+
 @test "update same any package to same repository fails" {
 	releasePackage extra pkg-any-a
 	db-update

--- a/test/lib/common.bash
+++ b/test/lib/common.bash
@@ -99,6 +99,8 @@ setup() {
 	export DBSCRIPTS_CONFIG=${TMP}/config.local
 	cat <<eot > "${DBSCRIPTS_CONFIG}"
 	FTP_BASE="${TMP}/ftp"
+	ARCHIVE_BASE="${TMP}/archive"
+	ARCHIVEUSER=""
 	SVNREPO="file://${TMP}/svn-packages-repo"
 	PKGREPOS=('core' 'extra' 'testing')
 	PKGPOOL='pool/packages'
@@ -125,6 +127,14 @@ eot
 	done
 	mkdir -p "${TMP}/ftp/${PKGPOOL}"
 	mkdir -p "${TMP}/ftp/${SRCPOOL}"
+
+	# make dummy packages for "reproducibility"
+	pacman -Qq | pacman -Sddp - | while read -r line; do
+		line=${line##*/}
+		pkgname=${line%-*-*-*}
+		mkdir -p "${ARCHIVE_BASE}/packages/${pkgname:0:1}/${pkgname}"
+		touch "${ARCHIVE_BASE}/packages/${pkgname:0:1}/${pkgname}/${line}"{,.sig}
+	done
 
 	svnadmin create "${TMP}/svn-packages-repo"
 	svn checkout -q "file://${TMP}/svn-packages-repo" "${TMP}/svn-packages-copy"


### PR DESCRIPTION
This partially subsumes the work of archivetools, in creating the initial `packages/${pkgname:0:1}/${pkgname}/${pkgfile}` pool every time a package is uploaded. (Archivetools only runs once per day and can miss things.)

And we now also test every package to make sure it can only be db-updated if the archive knows about all packages that were installed in the build environment.