### PR TITLE
Update mailing list address

### DIFF
--- a/config
+++ b/config
@@ -42,7 +42,7 @@ PKGEXTS=".pkg.tar.@(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz)"
 ALLOWED_LICENSES=('GPL' 'GPL1' 'GPL2' 'GPL3' 'LGPL' 'LGPL1' 'LGPL2' 'LGPL2.1' 'LGPL3')
 
 # Where to send error emails, and who they are from
-LIST="arch-dev-public@archlinux.org"
+LIST="arch-dev-public@lists.archlinux.org"
 #LIST="aaronmgriffin@gmail.com"
 FROM="repomaint@archlinux.org"
 


### PR DESCRIPTION
All the arch-x@archlinux.org -> arch-x@lists.archlinux.org aliases will
be dropped soon[1].

[1] https://lists.archlinux.org/pipermail/arch-dev-public/2021-June/030462.html