### PR TITLE
db-move: Check that the specified repositories are ones dbscripts was configured for

### DIFF
--- a/db-functions
+++ b/db-functions
@@ -404,6 +404,15 @@ chk_license() {
 	return 1
 }
 
+check_repo_configured() {
+	local repo=$1
+
+	local count=$(printf '%s\n' "${PKGREPOS[@]}" | grep --count --line-regexp "$repo")
+	[[ $count -gt 0 ]] && return 0
+
+	return 1
+}
+
 check_repo_permission() {
 	local repo=$1
 

--- a/db-move
+++ b/db-move
@@ -19,6 +19,12 @@ if in_array "${repo_from}" "${STAGING_REPOS[@]}" && in_array "${repo_to}" "${STA
 	check_leapfrog=true
 fi
 
+if ! check_repo_configured "$repo_from"; then
+	die "%s is not a configured repository" "$repo_from"
+elif ! check_repo_configured "$repo_to"; then
+	die "%s is not a configured repository" "$repo_to"
+fi
+
 if ! check_repo_permission "$repo_to" || ! check_repo_permission "$repo_from"; then
 	die "You don't have permission to move packages from %s to %s" "$repo_from" "$repo_to"
 fi


### PR DESCRIPTION
Otherwise if you use the dbscripts for core/extra for community repos,
or vice versa, you'll get an error saying that you don't have
permissions to move packages from or to the given repositories, which
can be confusing if you don't immediately notice your mistake.